### PR TITLE
Update link to CERN Cloud User guide

### DIFF
--- a/doc/openstack-ops/app_usecases.xml
+++ b/doc/openstack-ops/app_usecases.xml
@@ -251,9 +251,9 @@
                 <listitem>
                     <para>
                         <link
-                            xlink:href="http://information-technology.web.cern.ch/book/cern-private-cloud-user-guide"
+                            xlink:href="http://clouddocs.web.cern.ch/clouddocs/"
                             >CERN Cloud Infrastructure User
-                            Guide</link> (http://information-technology.web.cern.ch/book/cern-private-cloud-user-guide)</para>
+                            Guide</link> (http://clouddocs.web.cern.ch/clouddocs/)</para>
                 </listitem>
             </itemizedlist>
         </section>


### PR DESCRIPTION
The CERN team has moved their documentation to a new link.
